### PR TITLE
fix: block 'session-changed' for a duration

### DIFF
--- a/src/components/pie-player/pie-player.tsx
+++ b/src/components/pie-player/pie-player.tsx
@@ -36,8 +36,6 @@ export class Player {
    */
   stimulusPlayer: HTMLElement;
 
-  _loadCompleteState: boolean = false;
-
   @Prop({ context: "document" }) doc!: Document;
 
   @Element() el: HTMLElement;
@@ -136,7 +134,6 @@ export class Player {
   @Watch("config")
   async watchConfig(newConfig) {
     this.elementsLoaded = false;
-    this._loadCompleteState = false;
 
     // wrapping a player in stimulus layoute
     if (this.stimulusPlayer) {
@@ -216,6 +213,16 @@ export class Player {
       this.pieContentModel.markup &&
       this.elementsLoaded
     ) {
+      /**
+       * Block session changed events while we set model/session on the elements.
+       * TODO: The elements should *not* be firing 'session-changed' when the session is set.
+       * They should only fire this if a user has made a change. Can we guarantee that?
+       */
+      this.el.addEventListener(
+        SessionChangedEvent.TYPE,
+        this.stopEventFromPropagating
+      );
+
       this.pieContentModel.models.forEach(async (model, index) => {
         if (model && model.error) {
           this.playerError.emit(`error loading question data`);
@@ -263,21 +270,23 @@ export class Player {
               );
             }
           }
-          // by setting session we will trigger session-changed from PIE
-          // block this event, and set/emit load complete on receipt to not block future events
-          pieEl.addEventListener(SessionChangedEvent.TYPE, ev => {
-            if (!this._loadCompleteState) {
-              ev.stopPropagation();
-              if (this.pieContentModel.models.length === index + 1) {
-                this._loadCompleteState = true;
-                this.loadComplete.emit();
-              }
-            }
-          });
           pieEl.session = session;
         }
       });
+      setTimeout(() => {
+        /** remove the event blocker - see above */
+        this.el.removeEventListener(
+          SessionChangedEvent.TYPE,
+          this.stopEventFromPropagating
+        );
+        //TODO: is this needed anymore? maybe it should be using 'model-set' instead of 'session-changed' which is what it was using.
+        this.loadComplete.emit();
+      }, 150);
     }
+  }
+
+  private stopEventFromPropagating(e: CustomEvent) {
+    e.stopPropagation();
   }
 
   async componentWillLoad() {

--- a/src/demo/IBX-2459.html
+++ b/src/demo/IBX-2459.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Stencil Component Starter</title>
+    <script nomodule src="/build/pie-player-components.js"></script>
+    <script type="module" src="/build/pie-player-components.esm.js"></script>
+  </head>
+  <body>
+    <pie-player id="player"></pie-player>
+
+    <script>
+      const config = {
+        elements: {
+          "pie-element-explicit-constructed-response":
+            "@pie-element/explicit-constructed-response@3.0.1"
+        },
+        markup:
+          '<pie-element-explicit-constructed-response id="1"></pie-element-explicit-constructed-response>',
+        models: [
+          {
+            id: "1",
+            element: "pie-element-explicit-constructed-response",
+            markup: "<p>The {{0}} jumped {{1}} the {{2}}</p>",
+            disabled: false,
+            choices: {
+              "0": [
+                {
+                  label: "cow",
+                  value: "0"
+                },
+                {
+                  label: "cattle",
+                  value: "1"
+                },
+                {
+                  label: "calf",
+                  value: "2"
+                }
+              ],
+              "1": [
+                {
+                  label: "over",
+                  value: "0"
+                },
+                {
+                  label: "past",
+                  value: "1"
+                },
+                {
+                  label: "beyond",
+                  value: "2"
+                }
+              ],
+              "2": [
+                {
+                  label: "moon",
+                  value: "0"
+                }
+              ]
+            },
+            prompt: "Use the dropdowns to complete the sentence",
+            promptEnabled: true
+          }
+        ]
+      };
+      // const config = {
+      //   id: "1",
+      //   elements: {
+      //     "pie-multiple-choice": "@pie-element/multiple-choice@2.7.3"
+      //   },
+      //   models: [
+      //     {
+      //       id: "1",
+      //       element: "pie-multiple-choice",
+      //       prompt:
+      //         "Which of these northern European countries are EU members?",
+      //       choiceMode: "checkbox",
+      //       keyMode: "numbers",
+      //       choices: [
+      //         {
+      //           correct: true,
+      //           value: "sweden",
+      //           label: "Sweden",
+      //           feedback: {
+      //             type: "none",
+      //             value: ""
+      //           }
+      //         },
+      //         {
+      //           value: "iceland",
+      //           label: "Iceland",
+      //           feedback: {
+      //             type: "none",
+      //             value: ""
+      //           }
+      //         },
+      //         {
+      //           value: "norway",
+      //           label: "Norway",
+      //           feedback: {
+      //             type: "none",
+      //             value: ""
+      //           }
+      //         },
+      //         {
+      //           correct: true,
+      //           value: "finland",
+      //           label: "Finland",
+      //           feedback: {
+      //             type: "none",
+      //             value: ""
+      //           }
+      //         }
+      //       ],
+      //       partialScoring: false,
+      //       partialScoringLabel: `Each correct response that is correctly checked and each incorrect response
+      //       that is correctly unchecked will be worth 1 point.
+      //       The maximum points is the total number of answer choices.`
+      //     }
+      //   ],
+      //   markup: `
+      //     <pie-multiple-choice id='1'></pie-multiple-choice>
+      //   `
+      // };
+
+      // const config = {};
+
+      const player = document.getElementById("player");
+      document.addEventListener("session-changed", e => {
+        console.log(e);
+      });
+
+      player.addEventListener("sessionChanged", event => {
+        console.log(event.type + ":" + JSON.stringify(event.detail));
+      });
+
+      player.config = config;
+    </script>
+  </body>
+</html>

--- a/src/demo/player-multiple-choice.html
+++ b/src/demo/player-multiple-choice.html
@@ -78,7 +78,9 @@
 
       const player = document.getElementById("player");
 
-      player.addEventListener("sessionChanged", event => {
+      document.addEventListener("session-changed", e => console.log(">", e));
+
+      player.addEventListener("session-changed", event => {
         console.log(event.type + ":" + JSON.stringify(event.detail));
       });
 


### PR DESCRIPTION
We were depending on each element to send a 'session-changed' event to
consider that the load was complete, however this is an incorrect use of
the 'session-changed' event. It is designed to only fire when the user
has made a change, any element that is firing when the session is set is
using it incorrectly. Because we can't depend on the elements behaving
better in this regard, just block any event from propagating for a short
duration when the model/sessions are being set.

TODO: is 'loadComplete' in use? If so it should probably be looking at
the model set event for each el instead?