### PR TITLE
Fix/6765 configure

### DIFF
--- a/src/__tests__/pie-loader.spec.ts
+++ b/src/__tests__/pie-loader.spec.ts
@@ -1,44 +1,62 @@
 import { BundleType, needToLoad, PieLoader } from "../pie-loader";
-import { emptyConfigure } from "../components/empty-configure";
 import { PieContent } from "../interface";
 import { JSDOM } from "jsdom";
 const reg = (extras: any = {}) => ({ ...extras });
 
+const KEY = "pie-element";
+
 describe("needToLoad", () => {
-  const assertNeedToLoad = (
+  const assertNeedToLoad = (bundleType: BundleType) => (
     label: string,
     registry,
-    bundleType: BundleType,
-    key: string,
     expected: boolean
   ) => {
     it(label, () => {
-      const result = needToLoad(registry, bundleType)(`${key}@1.0.0`, key);
+      const result = needToLoad(registry, bundleType)(`${KEY}@1.0.0`, KEY);
       expect(result).toEqual(expected);
     });
   };
 
-  assertNeedToLoad("empty reg", reg(), BundleType.editor, "pie-element", true);
-  assertNeedToLoad(
-    "with empty reg object",
-    reg({ "pie-element": {} }),
-    BundleType.editor,
-    "pie-element",
-    true
-  );
+  const assertEditor = assertNeedToLoad(BundleType.editor);
+  const assertClientPlayer = assertNeedToLoad(BundleType.clientPlayer);
+  const assertPlayer = assertNeedToLoad(BundleType.player);
+  assertEditor("undefined reg", undefined, true);
+  assertEditor("empty reg", reg(), true);
+  assertEditor("with empty reg object", reg({ [KEY]: {} }), true);
 
-  assertNeedToLoad(
+  assertEditor(
     "with 3 objects",
     reg({
-      "pie-element": {
+      [KEY]: {
         config: {},
         controller: {},
         element: {}
       }
     }),
-    BundleType.editor,
-    "pie-element",
     false
+  );
+
+  assertClientPlayer(
+    "clientPlayer - missing element",
+    reg({ [KEY]: { controller: {} } }),
+    true
+  );
+  assertClientPlayer(
+    "clientPlayer - missing controller",
+    reg({ [KEY]: { element: {} } }),
+    true
+  );
+  assertClientPlayer(
+    "clientPlayer - ok",
+    reg({ [KEY]: { controller: {}, element: {} } }),
+    false
+  );
+
+  assertPlayer("player - ok", reg({ [KEY]: { element: {} } }), false);
+  assertPlayer(
+    "player - no element",
+    reg({ [KEY]: { element: undefined } }),
+    true
   );
 });
 

--- a/src/__tests__/pie-loader.spec.ts
+++ b/src/__tests__/pie-loader.spec.ts
@@ -1,0 +1,101 @@
+import { BundleType, needToLoad, PieLoader } from "../pie-loader";
+import { emptyConfigure } from "../components/empty-configure";
+import { PieContent } from "../interface";
+import { JSDOM } from "jsdom";
+const reg = (extras: any = {}) => ({ ...extras });
+
+describe("needToLoad", () => {
+  const assertNeedToLoad = (
+    label: string,
+    registry,
+    bundleType: BundleType,
+    key: string,
+    expected: boolean
+  ) => {
+    it(label, () => {
+      const result = needToLoad(registry, bundleType)(`${key}@1.0.0`, key);
+      expect(result).toEqual(expected);
+    });
+  };
+
+  assertNeedToLoad("empty reg", reg(), BundleType.editor, "pie-element", true);
+  assertNeedToLoad(
+    "with empty reg object",
+    reg({ "pie-element": {} }),
+    BundleType.editor,
+    "pie-element",
+    true
+  );
+
+  assertNeedToLoad(
+    "with 3 objects",
+    reg({
+      "pie-element": {
+        config: {},
+        controller: {},
+        element: {}
+      }
+    }),
+    BundleType.editor,
+    "pie-element",
+    false
+  );
+});
+
+describe("PieLoader", () => {
+  let _ce: any;
+  beforeAll(() => {
+    _ce = global.customElements;
+
+    global.customElements = {
+      define: jest.fn(),
+      whenDefined: jest.fn().mockResolvedValue(undefined),
+      get: jest.fn().mockReturnValue(undefined)
+    };
+  });
+  afterAll(() => {
+    global.customElements = _ce;
+  });
+  describe("loadCloudPies", () => {
+    it("doesnt define configure element when type is clientPlayer", async () => {
+      const loader = new PieLoader();
+
+      const d = new JSDOM({});
+
+      await loader.loadCloudPies({
+        bundle: BundleType.clientPlayer,
+        content: {
+          id: "1",
+          models: [],
+          markup: "",
+          elements: { "pie-el": "pie-el@latest" }
+        } as PieContent,
+        doc: d.window.document,
+        useCdn: false
+      });
+
+      // global.window = d.window;
+      window.pie = {
+        default: {
+          "pie-el": {
+            controller: jest.fn(),
+            Element: class extends HTMLElement {}
+          }
+        }
+      };
+      const scripts = d.window.document.querySelectorAll("script");
+      scripts.forEach(s => {
+        s.onload();
+      });
+
+      expect(customElements.define).toHaveBeenCalledWith(
+        "pie-el",
+        expect.anything()
+      );
+      expect(customElements.define).not.toHaveBeenCalledWith(
+        "pie-el-config",
+        expect.anything()
+      );
+    });
+  });
+});

--- a/src/components/empty-configure.tsx
+++ b/src/components/empty-configure.tsx
@@ -1,0 +1,36 @@
+export const emptyConfigure = (namespace: string) => {
+  const RENDER_KEY = "pie.empty-configure.render";
+  const out = class extends HTMLElement {
+    constructor() {
+      super();
+      const shadowRoot = this.attachShadow({ mode: "open" });
+      shadowRoot.innerHTML = `<div class="root">
+        <style>
+          .header{
+            color: red;
+            font-style: italic;
+            padding: 5px;
+            border: solid 1px red;
+          }
+          .root{
+            display: none;
+          }
+        </style>
+        <div class="header">An empty configure element is being rendered. This loader can't find a configure definition for ${namespace}. Note: this ui will only render if localStorage['${RENDER_KEY}'] is true</div>
+        <pre></pre>
+      </div>`;
+    }
+    set model(m) {
+      const renderData = localStorage.getItem(RENDER_KEY);
+
+      if (renderData) {
+        const root = this.shadowRoot.querySelector(".root");
+        root.setAttribute("style", "display: block");
+        const pre = this.shadowRoot.querySelector("pre");
+        pre.innerHTML = JSON.stringify(m, null, "  ");
+      }
+    }
+  };
+  (out as any)._emptyConfigure = true;
+  return out;
+};

--- a/src/components/pie-player/pie-player.tsx
+++ b/src/components/pie-player/pie-player.tsx
@@ -143,7 +143,7 @@ export class Player {
    */
   @Prop() renderStimulus: boolean = true;
 
-  @Prop({ mutable: false })
+  @Prop({ mutable: false, reflect: false })
   version: string = VERSION;
 
   @State() pieContentModel: PieContent;

--- a/src/demo/6765-empty-config.html
+++ b/src/demo/6765-empty-config.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Stencil Component Starter</title>
+    <script nomodule src="/build/pie-player-components.js"></script>
+    <script type="module" src="/build/pie-player-components.esm.js"></script>
+  </head>
+  <body>
+    <pie-player></pie-player>
+
+    <button id="add-pie-author">add author</button>
+
+    <script>
+      const config = {
+        id: "1",
+        elements: {
+          "pie-multiple-choice": "@pie-element/multiple-choice@2.7.3"
+        },
+        models: [
+          {
+            id: "1",
+            element: "pie-multiple-choice",
+            prompt:
+              "Which of these northern European countries are EU members?",
+            choiceMode: "checkbox",
+            keyMode: "numbers",
+            choices: [
+              {
+                correct: true,
+                value: "sweden",
+                label: "Sweden",
+                feedback: {
+                  type: "none",
+                  value: ""
+                }
+              },
+              {
+                value: "iceland",
+                label: `Iceland <math style="display: block;"> <mtable columnalign="right center left"> <mtr> <mtd> <msup> <mrow> <mo> ( </mo> <mi> a </mi> <mo> + </mo> <mi> b </mi> <mo> ) </mo> </mrow> <mn> 2 </mn> </msup> </mtd> <mtd> <mo> = </mo> </mtd> <mtd> <msup><mi> c </mi><mn>2</mn></msup> <mo> + </mo> <mn> 4 </mn> <mo> ⋅ </mo> <mo>(</mo> <mfrac> <mn> 1 </mn> <mn> 2 </mn> </mfrac> <mi> a </mi><mi> b </mi> <mo>)</mo>&nbsp;&nbsp;&nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;</mtd> </mtr> <mtr> <mtd> <msup><mi> a </mi><mn>2</mn></msup> <mo> + </mo> <mn> 2 </mn><mi> a </mi><mi> b </mi> <mo> + </mo> <msup><mi> b </mi><mn>2</mn></msup> </mtd> <mtd> <mo> = </mo> </mtd> <mtd> <msup><mi> c </mi><mn>2</mn></msup> <mo> + </mo> <mn> 2 </mn><mi> a </mi><mi> b</mi></mtd></mtr><mtr><mtd></mtd></mtr><mtr><mtd><msup><mi>a </mi><mn>2</mn></msup> <mo> + </mo> <msup><mi> b </mi><mn>2</mn></msup> </mtd> <mtd> <mo> = </mo> </mtd> <mtd> <msup><mi> c </mi><mn>2</mn></msup> </mtd> </mtr> </mtable> </math>`,
+                feedback: {
+                  type: "none",
+                  value: ""
+                }
+              },
+              {
+                value: "norway",
+                label: "Norway",
+                feedback: {
+                  type: "none",
+                  value: ""
+                }
+              },
+              {
+                correct: true,
+                value: "finland",
+                label: "Finland",
+                feedback: {
+                  type: "none",
+                  value: ""
+                }
+              }
+            ],
+            partialScoring: false,
+            partialScoringLabel: `Each correct response that is correctly checked and each incorrect response
+            that is correctly unchecked will be worth 1 point.
+            The maximum points is the total number of answer choices.`
+          }
+        ],
+        markup: `
+        <math xmlns="http://www.w3.org/1998/Math/MathML"><mfenced><mrow><mo>-</mo><mn>5</mn><mo>,</mo><mn>1</mn></mrow></mfenced></math> drafted by his assistant on a computer program which involves coordinate planes.&#160; The designer suggests to change the location and size of the lawn by dilating and then reflecting the lawn across the <span class="variable">x</span>-axis to produce the similar square lawn.&#160; The coordinates of the new square lawn are <math xmlns="http://www.w3.org/1998/Math/MathML"><mfenced><mrow><mo>-</mo><mn>4</mn><mo>,</mo><mo>-</mo><mn>2</mn></mrow></mfenced></math>, <math xmlns="http://www.w3.org/1998/Math/MathML"><mfenced><mrow><mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>2</mn></mrow></mfenced></math>,&#160;<math xmlns="http://www.w3.org/1998/Math/MathML"><mfenced><mrow><mo>-</mo><mn>4</mn><mo>,</mo><mo>-</mo><mn>4</mn></mrow></mfenced></math>, and <math xmlns="http://www.w3.org/1998/Math/MathML"><mfenced><mrow><mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>4</mn></mrow></mfenced></math>
+
+          <pie-multiple-choice id='1'></pie-multiple-choice>
+        `
+      };
+
+      // const config = {};
+
+      const player = document.querySelector("pie-player");
+
+      document.addEventListener("session-changed", e => console.log(">", e));
+
+      player.addEventListener("session-changed", event => {
+        console.log(event.type + ":" + JSON.stringify(event.detail));
+      });
+
+      player.addCorrectResponse = true;
+
+      player.config = config;
+
+      const addAuthor = document.querySelector("#add-pie-author");
+
+      addAuthor.addEventListener("click", () => {
+        const author = document.createElement("pie-author");
+        document.body.appendChild(author);
+        author.config = config;
+      });
+    </script>
+  </body>
+</html>

--- a/src/pie-loader.ts
+++ b/src/pie-loader.ts
@@ -58,6 +58,9 @@ export const needToLoad = (registry: any, bundle: BundleType) => (
   el: string,
   key: string
 ): boolean => {
+  if (!registry) {
+    return true;
+  }
   const regEntry: Entry = registry[key];
 
   if (!regEntry) {
@@ -65,15 +68,16 @@ export const needToLoad = (registry: any, bundle: BundleType) => (
   }
 
   const { config, controller, element } = regEntry;
-
-  if (bundle === BundleType.editor) {
-    return !config || !controller || !element;
-  } else if (bundle === BundleType.clientPlayer && (controller && element)) {
-    return false;
-  } else if (bundle === BundleType.player && element) {
-    return false;
+  switch (bundle) {
+    case BundleType.editor:
+      return !config || !controller || !element;
+    case BundleType.clientPlayer:
+      return !controller || !element;
+    case BundleType.player:
+      return !element;
+    default:
+      true;
   }
-  return true;
 };
 
 /**
@@ -220,6 +224,7 @@ export class PieLoader {
           }
 
           if (options.bundle === BundleType.editor) {
+            // This fixes some cases where the pie build service fails
             pie.Configure = isFunction(pie.Configure)
               ? pie.Configure
               : emptyConfigure(elName);
@@ -237,7 +242,6 @@ export class PieLoader {
               });
             }
           }
-          // This fixes some cases where the pie build service fails
         });
       };
     })(piesToLoad);


### PR DESCRIPTION
* only stub configure when loading editor (allows loading of clientPlayer, then editor on same page)
* add more detail to empty configure (visible with pie.empty-configure.render in localStorage)
* add test
* add demo page