### PR TITLE
feat: normalize elements

### DIFF
--- a/src/components/pie-author/__tests__/pie-author.e2e.ts
+++ b/src/components/pie-author/__tests__/pie-author.e2e.ts
@@ -64,7 +64,7 @@ describe("pie-author", () => {
     );
 
     await page.waitForChanges();
-    const configEl = await page.find("pie-author pie-multiple-choice-config");
+    const configEl = await page.find("pie-author pp-pie-element-multiple-choice-config");
     const model = await configEl.getProperty("model");
     expect(model.id).toEqual("1");
   });
@@ -87,7 +87,7 @@ describe("pie-author", () => {
     );
 
     await page.waitForChanges();
-    const configEl = await page.find("pie-author pie-multiple-choice-config");
+    const configEl = await page.find("pie-author pp-pie-element-multiple-choice-config");
     const model = await configEl.getProperty("model");
     expect(model.test).toEqual("test");
 
@@ -99,7 +99,7 @@ describe("pie-author", () => {
       copy
     );
     await page.waitForChanges();
-    const copyConfigEl = await page.find("pie-author pie-multiple-choice-config");
+    const copyConfigEl = await page.find("pie-author pp-pie-element-multiple-choice-config");
     const copyModel = await copyConfigEl.getProperty("model");
     expect(copyModel.test).toBeUndefined();
 
@@ -124,8 +124,8 @@ describe("pie-author", () => {
     );
 
     await page.waitForChanges();
-    await page.waitForSelector("pie-multiple-choice-config[model]");
-    const configEl = await page.find("pie-multiple-choice-config");
+    await page.waitForSelector("pp-pie-element-multiple-choice-config[model]");
+    const configEl = await page.find("pp-pie-element-multiple-choice-config");
     const configProp = await configEl.getProperty("configuration");
 
     expect(configProp.foo).toEqual("bar");
@@ -144,16 +144,14 @@ describe("pie-author", () => {
       "@pie-element/rubric"
     );
 
-    const tagName = Object.keys(rubricAdded.elements)[1];
-
     pieAuthor.setProperty("config", rubricAdded);
     await page.waitForChanges();
-    await page.waitForSelector(`pie-author ${tagName}-config:defined`, {
+    await page.waitForSelector(`pp-pie-element-rubric-config:defined`, {
       timeout: 1000
     });
 
     const rubricModel = await page.$eval(
-      `pie-author ${tagName}-config`,
+      `pie-author pp-pie-element-rubric-config`,
       el => (el as any).model
     );
     expect(rubricModel.foo).toEqual("bar");
@@ -167,39 +165,39 @@ describe("pie-author", () => {
     pieAuthor = await page.find("pie-author");
     pieAuthor.setProperty("config", multipleChoiceItem);
     await page.waitForChanges();
-    await page.waitForSelector("pie-author pie-multiple-choice-config:defined");
+    await page.waitForSelector("pie-author pp-pie-element-multiple-choice-config:defined");
     const pieModel = await page.$eval(
-      "pie-author pie-multiple-choice-config",
+      "pie-author pp-pie-element-multiple-choice-config",
       el => (el as any).model
     );
-    expect(pieModel.element).toEqual("pie-multiple-choice");
+    expect(pieModel.element).toEqual("pp-pie-element-multiple-choice");
 
     const mcPreviewPlayer = await page.find(
-      ".pie-player pie-player pie-multiple-choice"
+      ".pie-player pie-player pp-pie-element-multiple-choice"
     );
 
     const o = JSON.parse(mcPreviewPlayer.innerHTML);
     expect(o.model).toMatchObject({
-      model: { id: "1", element: "pie-multiple-choice" }
+      model: { id: "1", element: "pp-pie-element-multiple-choice" }
     });
 
     pieAuthor.setProperty("config", inlineChoiceItem);
     await page.waitForChanges();
-    await page.waitForSelector("pie-author pie-inline-choice-config:defined");
+    await page.waitForSelector("pie-author pp-pie-element-inline-choice-config:defined");
     const inlineChoiceModel = await page.$eval(
-      "pie-author pie-inline-choice-config",
+      "pie-author pp-pie-element-inline-choice-config",
       el => (el as any).model
     );
 
-    expect(inlineChoiceModel.element).toEqual("pie-inline-choice");
+    expect(inlineChoiceModel.element).toEqual("pp-pie-element-inline-choice");
 
     const icPreviewPlayer = await page.find(
-      ".pie-player pie-player pie-inline-choice"
+      ".pie-player pie-player pp-pie-element-inline-choice"
     );
 
     const switched = JSON.parse(icPreviewPlayer.innerHTML);
     expect(switched.model).toMatchObject({
-      model: { id: "1", element: "pie-inline-choice" }
+      model: { id: "1", element: "pp-pie-element-inline-choice" }
     });
   });
 });

--- a/src/components/pie-author/pie-author.tsx
+++ b/src/components/pie-author/pie-author.tsx
@@ -205,7 +205,7 @@ export class Author {
   addConfigTags(c: PieContent) {
     if (!c.markup && c.models) {
       const tags = c.models.map(model => {
-        return `<${model.element} id="${model.id}"></${model.element}-config>`;
+        return `<${model.element}-config id="${model.id}"></${model.element}-config>`;
       });
       c.markup = tags.join("");
     }

--- a/src/components/pie-player/__tests__/pie-player.e2e.ts
+++ b/src/components/pie-player/__tests__/pie-player.e2e.ts
@@ -26,11 +26,11 @@ describe("pie-player", () => {
     await piePlayer.setProperty("env", { mode: "evaluate", role: "student" });
     await page.waitForChanges();
     const pieElement = await page.waitForSelector(
-      "pie-player pie-multiple-choice"
+      "pie-player pp-pie-element-multiple-choice"
     );
     expect(pieElement).toBeDefined();
     const model = await page.$eval(
-      "pie-player pie-multiple-choice",
+      "pie-player pp-pie-element-multiple-choice",
       el => (el as any).model
     );
     expect(model.env.mode).toEqual("evaluate");
@@ -45,10 +45,10 @@ describe("pie-player", () => {
     const piePlayer = await page.find("pie-player");
     expect(piePlayer).toBeDefined();
     const pieElement = await page.waitForSelector(
-      "pie-player pie-multiple-choice"
+      "pie-player pp-pie-element-multiple-choice"
     );
     expect(pieElement).toBeDefined();
-    const model = await page.$eval("pie-player pie-multiple-choice", el =>
+    const model = await page.$eval("pie-player pp-pie-element-multiple-choice", el =>
       el.getAttribute("model")
     );
     expect(model).toBeTruthy();
@@ -60,11 +60,11 @@ describe("pie-player", () => {
     const secondPlayer = await page.find("pie-player");
     expect(secondPlayer).toBeDefined();
     const secondPieElement = await page.waitForSelector(
-      "pie-player:nth-child(2) pie-multiple-choice"
+      "pie-player:nth-child(2) pp-pie-element-multiple-choice"
     );
     expect(secondPieElement).toBeDefined();
     const model2 = await page.$eval(
-      "pie-player:nth-child(2) pie-multiple-choice",
+      "pie-player:nth-child(2) pp-pie-element-multiple-choice",
       el => el.getAttribute("model")
     );
     expect(model2).toBeTruthy();
@@ -78,8 +78,8 @@ describe("pie-player", () => {
       await piePlayer.setProperty("addCorrectResponse", true);
       await piePlayer.setProperty("config", simplePieMock);
       await page.waitForChanges();
-      await page.waitForSelector("pie-player pie-multiple-choice:defined");
-      const el = await page.find("pie-player pie-multiple-choice");
+      await page.waitForSelector("pie-player pp-pie-element-multiple-choice:defined");
+      const el = await page.find("pie-player pp-pie-element-multiple-choice");
       const d = JSON.parse(el.innerHTML);
       expect(d.session).toEqual({ correctResponse: true });
     });
@@ -94,12 +94,12 @@ describe("pie-player", () => {
     expect(piePlayer).toBeDefined();
     const stimulusLayout = await piePlayer.find("pie-stimulus-layout");
     expect(stimulusLayout).toBeDefined();
-    const passageModel = await page.$eval("#stimulusPlayer pie-passage", el =>
+    const passageModel = await page.$eval("#stimulusPlayer pp-pie-element-passage", el =>
       el.getAttribute("model")
     );
     expect(passageModel).toBeTruthy();
     const questionModel = await page.$eval(
-      "#itemPlayer pie-multiple-choice",
+      "#itemPlayer pp-pie-element-multiple-choice",
       el => el.getAttribute("model")
     );
     expect(questionModel).toBeTruthy();
@@ -141,11 +141,11 @@ describe("pie-player", () => {
 
     await page.waitForChanges();
     const pieElement = await page.waitForSelector(
-      "pie-player pie-multiple-choice"
+      "pie-player pp-pie-element-multiple-choice"
     );
     expect(pieElement).toBeDefined();
     const session = await page.$eval(
-      "pie-player pie-multiple-choice",
+      "pie-player pp-pie-element-multiple-choice",
       el => (el as any).session
     );
     expect(session).toEqual({ correctResponse: true });

--- a/src/components/pie-player/pie-player.tsx
+++ b/src/components/pie-player/pie-player.tsx
@@ -27,6 +27,7 @@ import {
   BundleEndpoints
 } from "../../pie-loader";
 import { addRubric } from "../../rubric-utils";
+import { normalizeContentElements } from "../../utils/utils";
 import { VERSION } from "../../version";
 
 const controllerErrorMessage: string =
@@ -159,7 +160,7 @@ export class Player {
   @Watch("config")
   async watchConfig(newConfig) {
     this.elementsLoaded = false;
-
+    
     // wrapping a player in stimulus layoute
     if (this.stimulusPlayer) {
       (this.stimulusPlayer as any).config = newConfig;
@@ -178,6 +179,7 @@ export class Player {
           return; // if stimulus item
         } else if (newConfig.elements) {
           this.pieContentModel = addRubric(newConfig);
+          this.pieContentModel = normalizeContentElements(this.pieContentModel);
         } else {
           this.playerError.emit(`invalid pie data model`);
           return;

--- a/src/demo/6835.html
+++ b/src/demo/6835.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>6825</title>
+    <script
+      type="text/javascript"
+      src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.js"
+    ></script>
+    <script nomodule src="/build/pie-player-components.js"></script>
+    <script type="module" src="/build/pie-player-components.esm.js"></script>
+    <style>
+      .error {
+        color: red;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Steps to repro:</h1>
+    <ol>
+      <li>Add author el</li>
+      <li>Set CR Config</li>
+      <li>Delete Author El</li>
+      <li>Add Author El</li>
+      <li>Set CR Config</li>
+      <li>Delete Author El</li>
+      <li>Add Author El</li>
+      <li class="error">Set CR Config</li>
+    </ol>
+    <button id="run-steps">Run all Steps...</button>
+    <button id="add">Add Author El</button>
+    <button id="delete">Delete Author El</button>
+    <hr />
+    <button id="set-cr-config">Set CR Config</button>
+    <button id="set-mc-config">Set Mc Config</button>
+
+    <div id="holder">holder</div>
+    <script type="module">
+      import { authorSettings } from "./item-configs.js";
+
+      console.log(authorSettings);
+      let author;
+      const holder = document.querySelector("#holder");
+
+      const addAuthor = () => {
+        console.log("add author..");
+        author = document.createElement("pie-author");
+        holder.appendChild(author);
+      };
+
+      const sleep = amount => {
+        console.log("sleep..");
+
+        return new Promise((resolve, reject) => {
+          setTimeout(() => {
+            console.log("sleep.done");
+            resolve();
+          }, amount);
+        });
+      };
+
+      document
+        .querySelector("#run-steps")
+        .addEventListener("click", async () => {
+          addAuthor();
+          await sleep(1000);
+          await setCrConfig();
+          author.remove();
+          await sleep(1000);
+          addAuthor();
+          await sleep(1000);
+          await setCrConfig();
+          author.remove();
+          await sleep(1000);
+          addAuthor();
+          await setCrConfig();
+        });
+
+      document.querySelector("#add").addEventListener("click", () => {
+        addAuthor();
+      });
+
+      document.querySelector("#delete").addEventListener("click", () => {
+        if (author) {
+          author.remove();
+        }
+      });
+      const setCrConfig = () => {
+        let contentConfig = _.cloneDeep(authorSettings["constructed_response"])
+          .contentConfig;
+        let configSettings = _.cloneDeep(
+          authorSettings["constructed_response"].configSettings
+        );
+
+        author.configSettings = configSettings;
+        console.log("... set config...");
+        return author
+          .addRubricToConfig(contentConfig)
+          .then(rubricModel => {
+            author.config = rubricModel;
+            console.log("new author config:", author.config);
+          })
+          .catch(error => {
+            console.error(error);
+          });
+      };
+      document.querySelector("#set-cr-config").addEventListener("click", () => {
+        // get clean copy of configs
+        setCrConfig();
+      });
+    </script>
+  </body>
+</html>

--- a/src/demo/item-configs.js
+++ b/src/demo/item-configs.js
@@ -1,0 +1,789 @@
+const authorSettings = {
+	multiple_choice: {
+		configSettings: {
+			'@pie-element/multiple-choice': {
+				answerChoiceCount: 4,
+				addChoiceButton: {
+					settings: true,
+					label: 'Add Choice'
+				},
+				choiceMode: {
+					settings: false,
+					label: 'Response Type'
+				},
+				lockChoiceOrder: {
+					settings: true,
+					label: 'Lock Choice Order'
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring'
+				},
+				choicePrefix: {
+					settings: true,
+					label: 'Choice Labels'
+				},
+				deleteChoice: {
+					settings: true
+				},
+				feedback: {
+					settings: false,
+					label: 'Student Feedback'
+				},
+				prompt: {
+					settings: true,
+					label: 'Item Stem'
+				},
+				rationale: {
+					settings: true,
+					label: 'Rationale'
+				},
+				studentInstructions: {
+					settings: false,
+					label: 'Student Instructions'
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions'
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-multiple-choice': '@pie-element/multiple-choice@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-multiple-choice',
+					choices: [],
+					choiceMode: 'radio',
+					choicePrefix: 'letters',
+					prompt: '',
+					lockChoiceOrder: false,
+					partialScoring: false,
+					scoringType: 'auto',
+					rationaleEnabled: false,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false,
+					feedbackEnabled: false
+				}
+			],
+			markup:
+				'<pie-multiple-choice id="p-00000000"></pie-multiple-choice>'
+		}
+	},
+	multiple_select: {
+		configSettings: {
+			'@pie-element/multiple-choice': {
+				answerChoiceCount: 5,
+				addChoiceButton: {
+					settings: true,
+					label: 'Add Choice'
+				},
+				choiceMode: {
+					settings: false,
+					label: 'Response Type'
+				},
+				lockChoiceOrder: {
+					settings: true,
+					label: 'Lock Choice Order'
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring'
+				},
+				choicePrefix: {
+					settings: true,
+					label: 'Choice Labels'
+				},
+				deleteChoice: {
+					settings: true
+				},
+				feedback: {
+					settings: false,
+					label: 'Student Feedback'
+				},
+				prompt: {
+					settings: true,
+					label: 'Item Stem'
+				},
+				rationale: {
+					settings: true,
+					label: 'Rationale'
+				},
+				studentInstructions: {
+					settings: false,
+					label: 'Student Instructions'
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions'
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-multiple-choice': '@pie-element/multiple-choice@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-multiple-choice',
+					choices: [],
+					choiceMode: 'checkbox',
+					choicePrefix: 'letters',
+					prompt: '',
+					lockChoiceOrder: false,
+					partialScoring: false,
+					scoringType: 'auto',
+					rationaleEnabled: false,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false,
+					feedbackEnabled: false
+				}
+			],
+			markup:
+				'<pie-multiple-choice id="p-00000000"></pie-multiple-choice>'
+		}
+	},
+	constructed_response: {
+		configSettings: {
+			'@pie-element/extended-text-entry': {
+				dimensions: {
+					settings: true,
+					label: 'Response Area Size'
+				},
+				equationEditor: {
+					settings: true,
+					label: '',
+					enabled: true
+				},
+				feedback: {
+					settings: false,
+					label: 'Feedback'
+				},
+				mathInput: {
+					settings: true,
+					label: 'Equation Editor',
+					enabled: false
+				},
+				multiple: {
+					settings: false,
+					label: 'Multiple Parts',
+					enabled: false
+				},
+				studentInstructions: {
+					settings: false,
+					label: 'Student Instructions'
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions'
+				},
+				prompt: {
+					settings: true,
+					label: 'Item Stem'
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-constructed-response':'@pie-element/extended-text-entry@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-constructed-response',
+					dimensions: { height: 100, width: 500 },
+					prompt: '',
+					mathInput: false,
+					equationEditor: 'everything',
+					feedbackEnabled: false,
+					rationaleEnabled: false,
+					promptEnabled: true,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false,
+					feedback: {
+						type: 'default',
+						default: ''
+					},
+					showMathInput: false
+				}
+			],
+			markup:
+				'<pie-constructed-response id="p-00000000"></pie-constructed-response>'
+		}
+	},
+	explicit_constructed_response: {
+		configSettings: {
+			'@pie-element/explicit-constructed-response': {
+				prompt: {
+					settings: true,
+					label: 'Item Stem'
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring',
+				},
+				rationale: {
+					settings: true,
+					label: 'Rationale'
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions'
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-explicit-constructed-response':
+					'@pie-element/explicit-constructed-response@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-explicit-constructed-response',
+					disabled: false,
+					mode: 'gather',
+					prompt: '<div></div>',
+					shuffle: true,
+					choices: {},
+					slateMarkup: '<div></div>',
+					rationaleEnabled: false,
+					promptEnabled: true,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false
+				}
+			],
+			markup:
+				'<pie-explicit-constructed-response id="p-00000000"></pie-explicit-constructed-response>'
+		}
+	},
+	math_equation_response: {
+		configSettings: {
+			'@pie-element/math-inline': {
+				responseType: {
+					settings: false,
+					label: 'Response type'
+				},
+				rationale: {
+					settings: true,
+					label: 'Rationale'
+				},
+				scoringType: {
+					settings: false,
+					label: 'Scoring Type'
+				},
+				studentInstructions: {
+					settings: false,
+					label: 'Student Instructions'
+				},
+				teacherInstructions: {
+					settings: false,
+					label: 'Teacher Instructions'
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring'
+				},
+				prompt: {
+					settings: true,
+					label: 'Prompt'
+				},
+				feedback: {
+					"settings": true,
+					"label": "Feedback"
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-math-inline': '@pie-element/math-inline@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					partialScoring: false,
+					responseType: 'Simple',
+					element: 'pie-math-inline',
+					equationEditor: '3',
+					expression: '',
+					rationale: '',
+					prompt: '',
+					responses: [
+						{
+							id: '1',
+							answer: '',
+							validation: 'literal'
+						}
+					],
+					customKeys: [
+						'\\left(\\right)',
+						'\\frac{}{}',
+						'x\\frac{}{}'
+					],
+					scoringType: 'auto',
+					response: {
+						answer: '',
+						validation: 'literal',
+					},
+					feedbackEnabled: false,
+					rationaleEnabled: false,
+					promptEnabled: true,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false
+				}
+			],
+			markup: '<pie-math-inline id="p-00000000"></pie-math-inline>'
+		}
+	},
+	evidence_based_selected_response: {
+		configSettings: {
+			'@pie-element/ebsr': {
+				addChoiceButton: {
+					settings: true,
+					label: 'Add Choice'
+				},
+				choiceMode: {
+					settings: true,
+					label: 'Response Type'
+				},
+				choicePrefix: {
+					settings: true,
+					label: 'Choice Labels'
+				},
+				deleteChoice: {
+					settings: true
+				},
+				feedback: {
+					settings: false,
+					label: 'Feedback'
+				},
+				prompt: {
+					settings: true,
+					label: 'Item Stem'
+				},
+				lockChoiceOrder: {
+					settings: true,
+					label: 'Lock Choice Order'
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring',
+					enabled: false
+				},
+				rationale: {
+					settings: true,
+					label: 'Rationale'
+				},
+				scoringType: {
+					settings: false,
+					label: 'Scoring Type'
+				},
+				studentInstructions: {
+					settings: false,
+					label: 'Student Instructions',
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions',
+				},
+				sequentialChoiceLabels: {
+					settings: false,
+					label: 'Sequential Choice Labels',
+					enabled: false
+				},
+				partLabels: {
+					settings: false,
+					label: 'Part Labels',
+					enabled: false
+				},
+				answerChoiceCount: 4
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-element-ebsr': '@pie-element/ebsr@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-element-ebsr',
+					partA: {
+						choices: [],
+						choiceMode: 'radio',
+						choicePrefix: 'letters',
+						prompt: '',
+						lockChoiceOrder: false,
+						partialScoring: false,
+						scoringType: 'auto',
+						keyMode: 'letters',
+						partialScoringLabel: '',
+						shuffle: false,
+						showCorrect: false,
+						allowFeedback: false,
+						feedbackEnabled: false,
+						promptEnabled: true,
+						rationaleEnabled: false,
+						teacherInstructionsEnabled: false,
+						studentInstructionsEnabled: false
+					},
+					partB: {
+						choices: [],
+						choiceMode: 'checkbox',
+						choicePrefix: 'letters',
+						prompt: '',
+						lockChoiceOrder: false,
+						partialScoring: false,
+						scoringType: 'auto',
+						keyMode: 'numbers',
+						partialScoringLabel: '',
+						shuffle: false,
+						allowFeedback: false,
+						feedbackEnabled: false,
+						promptEnabled: true,
+						rationaleEnabled: false,
+						teacherInstructionsEnabled: false,
+						studentInstructionsEnabled: false
+					}
+				}
+			],
+			markup: '<pie-element-ebsr id="p-00000000"></pie-element-ebsr>'
+		}
+	},
+	inline_dropdown: {
+		configSettings: {
+			'@pie-element/inline-dropdown': {
+				prompt: {
+					settings: true,
+					label: 'Item Stem'
+				},
+				lockChoiceOrder: {
+					settings: true,
+					label: 'Lock Choice Order'
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring'
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions'
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-inline-dropdown': '@pie-element/inline-dropdown@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-inline-dropdown',
+					disabled: false,
+					mode: 'gather',
+					prompt: '<div></div>',
+					shuffle: true,
+					choices: {},
+					slateMarkup: '<div></div>',
+					lockChoiceOrder: false,
+					promptEnabled: true,
+					rationaleEnabled: false,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false
+				}
+			],
+			markup:
+				'<pie-inline-dropdown id="p-00000000"></pie-inline-dropdown>'
+		}
+	},
+	hot_text: {
+		configSettings: {
+			'@pie-element/select-text': {
+				selectionCount: {
+					settings: false,
+					label: 'Selection Count'
+				},
+				correctAnswer: {
+					settings: false,
+					label: 'Correct Answers'
+				},
+				selections: {
+					settings: false,
+					label: 'Selections Available'
+				},
+				highlightChoices: {
+					settings: true,
+					label: 'Highlight Choices'
+				},
+				rationale: {
+					settings: true,
+					label: 'Rationale'
+				},
+				scoringType: {
+					settings: false,
+					label: 'Scoring Type'
+				},
+				studentInstructions: {
+					settings: false,
+					label: 'Student Instructions'
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions'
+				},
+				prompt: {
+					label: 'Item Stem'
+				},
+				text: {
+					settings: true,
+					label: 'Enter Content'
+				},
+				tokens: {
+					settings: true,
+					label: 'Tokens'
+				},
+				feedback: {
+					settings: false,
+					label: 'Student Feedback'
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring'
+				},
+				mode: {
+					settings: false,
+					label: 'Mode'
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-select-text': '@pie-element/select-text@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-select-text',
+					highlightChoices: true,
+					partialScoring: false,
+					maxSelections: 2,
+					mode: 'sentence',
+					prompt: '<div></div>',
+					text: '',
+					tokens: [],
+					scoringType: 'auto',
+					feedback: {
+						correct: {
+							type: 'default',
+							default: 'Correct'
+						},
+						incorrect: {
+							type: 'default',
+							default: 'Incorrect'
+						},
+						partial: {
+							type: 'default',
+							default: 'Nearly'
+						}
+					},
+					feedbackEnabled: false,
+					rationaleEnabled: false,
+					promptEnabled: true,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false
+				}
+			],
+			markup: '<pie-select-text id="p-00000000"></pie-select-text>'
+		}
+	},
+	hot_spot: {
+		configSettings: {
+			'@pie-element/hotspot': {
+				multipleCorrect: {
+					settings: true,
+					label: 'Multiple Correct Responses',
+					enabled: false
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring'
+				},
+				rationale: {
+					settings: true,
+					label: 'Rationale'
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions'
+				},
+				prompt: {
+					settings: true,
+					label: 'Prompt',
+					enabled: true
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-hotspot': '@pie-element/hotspot@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-hotspot',
+					prompt: '',
+					imageUrl: '',
+					shapes: {
+						rectangles: [],
+						polygons: []
+					},
+					multipleCorrect: false,
+					partialScoring: false,
+					dimensions: {
+						height: 0,
+						width: 0
+					},
+					hotspotColor: 'rgba(137, 183, 244, 0.65)',
+					hotspotList: [
+						'rgba(137, 183, 244, 0.65)',
+						'rgba(217, 30, 24, 0.65)',
+						'rgba(254, 241, 96, 0.65)'
+					],
+					outlineColor: 'blue',
+					outlineList: ['blue', 'red', 'yellow'],
+					rationaleEnabled: false,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false
+				}
+			],
+			markup: '<pie-hotspot id="p-00000000"></pie-hotspot>'
+		}
+	},
+	drag_in_the_blank: {
+		configSettings: {
+			'@pie-element/drag-in-the-blank': {
+				prompt: {
+					settings: true,
+					label: 'Item Stem'
+				},
+				duplicates: {
+					settings: true,
+					label: 'Allow Duplicates'
+				},
+				lockChoiceOrder: {
+					settings: true,
+					label: 'Lock Choice Order'
+				},
+				partialScoring: {
+					settings: false,
+					label: 'Allow Partial Scoring'
+				},
+				rationale: {
+					settings: true,
+					label: 'Rationale'
+				},
+				studentInstructions: {
+					settings: false,
+					label: 'Student Instructions'
+				},
+				teacherInstructions: {
+					settings: true,
+					label: 'Teacher Instructions'
+				}
+			}
+		},
+		contentConfig: {
+			id: 'p-00000000',
+			elements: {
+				'pie-drag-in-the-blank': '@pie-element/drag-in-the-blank@latest'
+			},
+			models: [
+				{
+					id: 'p-00000000',
+					element: 'pie-drag-in-the-blank',
+					disabled: false,
+					mode: 'gather',
+					shuffle: true,
+					prompt: '<div></div>',
+					choices: [],
+					choicesPosition: 'below',
+					correctResponse: {},
+					duplicates: false,
+					partialScoring: false,
+					slateMarkup: '<div></div>',
+					rationaleEnabled: false,
+					promptEnabled: true,
+					teacherInstructionsEnabled: false,
+					studentInstructionsEnabled: false
+				}
+			],
+			markup:
+				'<pie-drag-in-the-blank id="p-00000000"></pie-drag-in-the-blank>'
+		}
+	}
+}
+const ibxItemTypes = [
+	{
+		name: 'Multiple Choice',
+		id: 'multiple_choice',
+		symbol: 'Multiple Choice_1'
+	},
+	{
+		name: 'Multiple Select',
+		id: 'multiple_select',
+		symbol: 'Multiple Choice_1'
+	},
+	{
+		name: 'Constructed Response',
+		id: 'constructed_response',
+		symbol: 'Constructed Response_1'
+	},
+	{
+		name: 'Explicit Constructed Response',
+		id: 'explicit_constructed_response',
+		symbol: 'Constructed Response_1'
+	},
+	{
+		name: 'Math Equation Response',
+		id: 'math_equation_response',
+		symbol: 'Math Equation Response_1'
+	},
+	{
+		name: 'EBSR',
+		id: 'evidence_based_selected_response',
+		symbol: 'Evidence-Based Selected Response_1'
+	},
+	{
+		name: 'Inline Dropdown',
+		id: 'inline_dropdown',
+		symbol: 'Inline Dropdown_1'
+	},
+	{
+		name: 'Hot Text',
+		id: 'hot_text',
+		symbol: 'Hot Text_1'
+	},
+	{
+		name: 'Hot Spot',
+		id: 'hot_spot',
+		symbol: 'Hot Spot_1'
+	},
+	{
+		name: 'Drag in the Blank',
+		id: 'drag_in_the_blank',
+		symbol: 'Drag and Drop_1'
+	}
+]
+export { authorSettings, ibxItemTypes }

--- a/src/pie-loader.ts
+++ b/src/pie-loader.ts
@@ -251,31 +251,8 @@ export class PieLoader {
     head.appendChild(script);
   };
 
-  public convertPieContent = (
-    content: PieContent,
-    forAuthoring = true
-  ): PieContent => {
-    let c = content;
-    if (forAuthoring) {
-      if (!c.markup && c.models) {
-        const tags = content.models.map(model => {
-          return `<${model.element} id="${model.id}"></${
-            model.element
-          }-config>`;
-        });
-        c.markup = tags.join("");
-      }
-    }
+  
 
-    return c;
-  };
-
-  /**
-   *
-   * @param content the `PieContent` to process
-   * @param useVersions whether different (major) versions of elements will be managed separately
-   */
-  public normalizeElements(content: PieContent, useVersions: true) {}
 
   /**
    * Given a defintion of elements, will check the registry

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -1,7 +1,36 @@
-import { getPackageWithoutVersion, getPackageBundleUri, elementsHasPackage, modelsForPackage, elementForPackage } from './utils';
+import { getPackageWithoutVersion, getPackageBundleUri, elementsHasPackage, modelsForPackage, elementForPackage, packageToElementName, normalizeContentElements } from './utils';
 import { PieContent } from '../interface';
 
 describe('package utils', () => {
+
+  it('converts npm package to element name', () => {
+    expect(packageToElementName("@pie-elements/multiple-choice@1.2.2")).toEqual('pie-elements-multiple-choice');
+    expect(packageToElementName("multiple-choice@1.2.2")).toEqual('multiple-choice');
+    expect(packageToElementName("foo")).toEqual('foo');
+  });
+
+
+  it('normalizes content tlement names with package-based element names', () => {
+    const mockContent = {
+      id: "",
+      elements: {
+        "el-foo": "foo-package",
+        "el-bar": "@bar-scope/bar-package@1.0.0",
+        "el-baz": "baz"
+      },
+      models: [{id: "1", element:"el-foo"}],
+      markup: '<el-foo></el-foo> <el-bar></el-bar> <el-baz></el-baz>'
+    }
+    const normalized = normalizeContentElements(mockContent);
+    expect(normalized.markup).toEqual('<pp-foo-package></pp-foo-package> <pp-bar-scope-bar-package></pp-bar-scope-bar-package> <pp-baz></pp-baz>');
+    expect(normalized.models).toEqual([{id:"1", element:"pp-foo-package"}]);
+    expect(normalized.elements['pp-foo-package']).toEqual("foo-package");
+    expect(normalized.elements["el-foo"]).toBeUndefined();
+
+  });
+
+
+
   it('removes version from package names', () => {
     expect(getPackageWithoutVersion("@pie-elements/multiple-choice@1.2.2")).toEqual('@pie-elements/multiple-choice');
     expect(getPackageWithoutVersion("@pie-elements/multiple-choice@latest")).toEqual('@pie-elements/multiple-choice');


### PR DESCRIPTION
The pie config spec lets a user map packages
with element names, models and markup.

For the purposes of browser rendering we
want to control the element tag names used to
allow control over custom element management / loading.

This fixes:ch6835 which was caused due to
different tag names for same element.