### PR TITLE
fix(player): updated components css [PD-175 and PD-221]

### DIFF
--- a/src/components/components.css
+++ b/src/components/components.css
@@ -77,3 +77,435 @@
     transform: rotate(360deg);
   }
 }
+
+.pie-api-player img {
+  max-width: inherit;
+  max-height: inherit;
+}
+
+/* These styles are used in the body content of an item -- they also appear in the item body editor. */
+
+.book-title-k5 {
+  text-decoration: underline;
+}
+
+.book-title {
+  font-style: italic;
+}
+
+.block-quote {
+  font-family: serif;
+  margin-left: 20%;
+  margin-right: 20%;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  width: 60%;
+  border: 1px solid black;
+  padding: 2px;
+  display: block;
+}
+
+.text-block {
+  font-family: serif;
+  margin-left: 20%;
+  margin-right: 20%;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  width: 60%;
+  border: 1px solid black;
+  padding: 2px;
+  display: block;
+}
+
+.short-quote {
+  font-weight: bold;
+}
+
+span.short-quote:before {
+  content: open-quote;
+}
+
+span.short-quote:after {
+  content: close-quote;
+}
+
+.word-callout {
+  text-decoration: underline;
+}
+
+.relative-emphasis {
+  text-transform: uppercase;
+}
+
+.content-emphasis {
+  font-weight: bold;
+  color: red;
+}
+
+span.passage-title:before {
+  content: open-quote;
+}
+
+span.passage-title:after {
+  content: close-quote;
+}
+
+.proper-name {
+  font-style: italic;
+}
+
+.variable {
+  font-style: italic;
+}
+
+.equation-block {
+  text-align: center;
+  margin-left: 20%;
+  margin-right: 20%;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  width: 60%;
+  padding: 2px;
+  display: block;
+}
+
+.embedded-error {
+  font-style: italic;
+}
+
+/* PASSAGES */
+
+div.passage-title,
+div.passage-subtitle {
+  font-weight: bold;
+  text-align: center;
+}
+
+div.passage-author {
+  text-align: center;
+}
+
+.p-number {
+  float: left;
+  font-size: 0.85em;
+}
+
+.numbered-paragraph {
+  margin-left: 36px;
+}
+
+/* ch5680 - also temporary kds content styles that need to be externalized */
+/* Inspect Styles */
+
+@media print {
+  .kds-noprint {
+    display: none;
+  }
+
+  .noprint {
+    display: none;
+  }
+}
+
+.kds-absolute {
+  border-left: 1px solid black;
+  border-right: 1px solid black;
+  padding: 0px 0.3em 0px 0.3em;
+}
+
+.abs {
+  border-left: #000000 1px solid;
+  border-right: #000000 1px solid;
+  padding: 0px 0.3em 0px 0.3em;
+}
+
+.kds-border-1 {
+  border: 1px solid black;
+}
+
+.kds-border-2 {
+  border: 2px solid black;
+}
+
+.kds-center {
+  margin: 0px;
+  text-align: center;
+}
+
+.center {
+  text-align: center;
+  margin: 0;
+}
+
+.kds-exponent {
+  font-size: 85%;
+  margin-left: -0.4em;
+  position: relative;
+  top: -1.4em;
+}
+
+sup.frac {
+  position: relative;
+  top: -1.4em;
+  font-size: 70%;
+  margin-left: -0.4em;
+}
+
+.kds-fillin {
+  border: 1px solid black;
+  display: inline-block;
+  margin: 0em 0.2em;
+  padding-left: 1em;
+}
+
+.fillin {
+  margin: 0em 0.2em;
+  padding-left: 1em;
+  border: #000000 1px solid;
+  display: inline-block;
+  *display: inline;
+}
+
+.kds-font-larger {
+  font-size: larger;
+}
+
+.kds-font-smaller {
+  font-size: smaller;
+}
+
+table.kds-fraction {
+  border: 0px;
+  display: inline-block;
+  font-size: 85%;
+  margin: 0px;
+  padding: 0px;
+  vertical-align: middle;
+}
+
+table.kds-fraction > tbody > tr > td.kds-numerator {
+  border-bottom: 1px solid black;
+  border-left: 0px;
+  border-right: 0px;
+  border-top: 0px;
+  text-align: center;
+}
+
+table.kds-fraction > tbody > tr > td.kds-denominator {
+  border: 0px;
+  text-align: center;
+}
+
+table.frac {
+  display: inline-block;
+  *display: inline;
+  vertical-align: middle;
+  font-size: 85%;
+  border: 0px;
+  margin: 0px;
+  padding: 0px;
+}
+
+.frac .nu {
+  border-left: 0px;
+  border-top: 0px;
+  border-right: 0px;
+  border-bottom: #000000 1px solid;
+  text-align: center;
+}
+
+.frac .de {
+  border: 0px;
+  text-align: center;
+}
+
+.kds-hanging-indent {
+  margin: 0px;
+  padding-left: 3em;
+  text-indent: -3em;
+}
+
+.kds-image-caption {
+  font-family: Verdana, Arial, sans-serif;
+  text-align: center;
+}
+
+.kds-image-left {
+  float: left;
+  margin-right: 5px;
+}
+
+.kds-image-right {
+  float: right;
+  margin-left: 5px;
+}
+
+.kds-indent {
+  text-indent: 3em;
+}
+
+.indent {
+  text-indent: 3em;
+}
+
+.kds-nowrap {
+  display: inline-block;
+  white-space: nowrap;
+}
+
+.kds-overline {
+  text-decoration: overline;
+}
+
+.kds-parentheses {
+  font-family: "Arial Narrow", Arial, sans-serif;
+  font-size: 300%;
+  font-weight: normal;
+  position: relative;
+  top: 8px;
+}
+
+b.frac {
+  font-weight: normal;
+  font-size: 300%;
+  font-family: arial narrow;
+  position: relative;
+  top: +8px;
+}
+
+.kds-pi {
+  font-family: "Times New Roman", serif;
+  font-size: 1.2em;
+}
+
+.newradical {
+  border-collapse: collapse;
+  display: inline-block;
+  *display: inline;
+  vertical-align: middle;
+}
+
+.newradical td {
+  border: 0px;
+  padding: 0px;
+  vertical-align: top;
+}
+
+.newradical td.vinculum {
+  border-top: 1px solid black;
+  padding: 0px;
+  vertical-align: top;
+}
+
+.newradical div.exp {
+  font-size: 0.7em;
+  position: relative;
+  left: 7px;
+  bottom: 5px;
+}
+
+.kds-underline {
+  text-decoration: underline;
+}
+
+.under {
+  text-decoration: underline;
+}
+
+.kds-verdana2t {
+  border: 1px solid white;
+  text-align: left;
+  text-decoration: none;
+  vertical-align: top;
+}
+
+.Verdana2t {
+  vertical-align: top;
+  text-align: left;
+  text-decoration: none;
+  border: 1px solid white;
+}
+
+.kds-whole-number {
+  display: inline-block;
+  font-size: 120%;
+  margin: 0em 0em 0em 0.2em;
+}
+
+.whole {
+  display: inline-block;
+  *display: inline;
+  margin: 0em 0em 0em 0.2em;
+  font-size: 120%;
+}
+
+table.KdsTable01 {
+  border: 1px solid black;
+  border-collapse: collapse;
+  border-spacing: 0px;
+}
+
+table.KdsTable01 > tbody > tr > th {
+  background-color: #d3d3d3;
+  border: 1px solid black;
+  font-weight: normal;
+  padding: 2px;
+  text-align: center;
+}
+
+table.KdsTable01 > tbody > tr > th.bold {
+  background-color: #d3d3d3;
+  border: 1px solid black;
+  font-weight: bold;
+  padding: 2px;
+  text-align: center;
+}
+
+table.KdsTable01 > tbody > tr > td {
+  border: 1px solid black;
+  padding: 2px;
+  text-align: center;
+}
+
+table.KdsTable01 > tbody > tr > td.bold {
+  border: 1px solid black;
+  font-weight: bold;
+  padding: 2px;
+  text-align: center;
+}
+
+table.KdsTable02 {
+  border: 1px solid black;
+  border-collapse: collapse;
+  border-spacing: 0px;
+}
+
+table.KdsTable02 > tbody > tr > th {
+  background-color: #d3d3d3;
+  border: 1px solid black;
+  font-weight: normal;
+  padding: 2px;
+}
+
+table.KdsTable02 > tbody > tr > td {
+  border: 1px solid black;
+  padding: 2px;
+}
+
+/* LEARNOSITY OVERRIDES */
+.lrn_feature h3 {
+  margin-top: 0 !important;
+}
+
+/* PIE OVERRIDES */
+
+#stimulus {
+  width: 50%;
+  float: left;
+}
+
+#item {
+  width: 50%;
+  float: left;
+}
+

--- a/src/demo/PD-175.html
+++ b/src/demo/PD-175.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+  />
+  <title>Stencil Component Starter</title>
+  <script nomodule src="/build/pie-player-components.js"></script>
+  <script type="module" src="/build/pie-player-components.esm.js"></script>
+</head>
+<body>
+<pie-player id="player"></pie-player>
+
+<script>
+  const config = {
+    elements: {
+      "pie-element-multiple-choice":
+        "@pie-element/multiple-choice@latest"
+    },
+    markup:
+      '<pie-element-multiple-choice id="1"></pie-element-multiple-choice>',
+    models: [
+      {
+        "disabled": false,
+        "mode": "gather",
+        "prompt": "<div>A true number sentence is created when which sign is put in the box below?<br /><br />18 <div class=\"kds-fillin\">&#160;</div>&#160;6 = 12</div>",
+        "choiceMode": "radio",
+        "keyMode": "letters",
+        "shuffle": false,
+        "choices": [
+          {
+            "label": "<p>+</p>",
+            "value": "8a80808163e095450163e51729ef26c7",
+            "rationale": null
+          },
+          {
+            "label": "<p>&#8211;</p>",
+            "value": "8a80808163e095450163e51729ef26c8",
+            "rationale": null
+          },
+          {
+            "label": "<p>&#215;</p>",
+            "value": "8a80808163e095450163e51729ef26c9",
+            "rationale": null
+          },
+          {
+            "label": "<p>&#247;</p>",
+            "value": "8a80808163e095450163e51729ef26ca",
+            "rationale": null
+          }
+        ],
+        "complete": {
+          "min": 1
+        },
+        "teacherInstructions": null,
+        "element": "pie-element-multiple-choice",
+        "id": "1"
+      }        ]
+  };
+
+  const player = document.getElementById("player");
+  document.addEventListener("session-changed", e => {
+    console.log(e);
+  });
+
+  player.addEventListener("sessionChanged", event => {
+    console.log(event.type + ":" + JSON.stringify(event.detail));
+  });
+
+  player.config = config;
+</script>
+</body>
+</html>

--- a/src/demo/PD-221.html
+++ b/src/demo/PD-221.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+  />
+  <title>Stencil Component Starter</title>
+  <script nomodule src="/build/pie-player-components.js"></script>
+  <script type="module" src="/build/pie-player-components.esm.js"></script>
+</head>
+<body>
+<pie-player id="player"></pie-player>
+
+<script>
+  const config = {
+    elements: {
+      "pie-element-number-line":
+        "@pie-element/number-line@latest"
+    },
+    markup:
+      '<pie-element-number-line id="1"></pie-element-number-line>',
+    models: [
+      {
+        "prompt": "<div>Place a point on the number line where&#160;<table class=\"kds-fraction\"><tbody><tr><td class=\"kds-numerator\">1</td></tr><tr><td class=\"kds-denominator\">4</td></tr></tbody></table>&#160; is located.</div>",
+        "graph": {
+          "availableTypes": {
+            "PF": true
+          },
+          "maxNumberOfPoints": 1,
+          "height": 300,
+          "initialElements": [],
+          "width": 500,
+          "initialType": "PF",
+          "domain": {
+            "min": 0,
+            "max": 1
+          },
+          "ticks": {
+            "major": 1,
+            "minor": 0.25
+          }
+        },
+        "colorContrast": "black_on_white",
+        "element": "pie-element-number-line",
+        "id": "1"
+      }
+    ]
+  };
+
+  const player = document.getElementById("player");
+  document.addEventListener("session-changed", e => {
+    console.log(e);
+  });
+
+  player.addEventListener("sessionChanged", event => {
+    console.log(event.type + ":" + JSON.stringify(event.detail));
+  });
+
+  player.config = config;
+</script>
+</body>
+</html>


### PR DESCRIPTION
It was reported that in ibx Browse Items, some styles are not loaded properly (kds-fillin PD-175) and math markups (PD-221), so I just imported the entire css content from pie-api-components pie-api-author/pie-api-author.css.

To be discussed with Ed if this is a good solution for the issue.