### PR TITLE
fix: math rendering override style for prime symbol - PD-467

### DIFF
--- a/src/components/components.css
+++ b/src/components/components.css
@@ -570,3 +570,7 @@ h1, h2, h3, h4, h5, h6 {
 .MJX-TEX * {
   font-family: MJXZERO, MJXTEX !important;
 }
+
+mjx-c.mjx-c2032 {
+  font-family: 'CerebriSans', serif !important;
+}


### PR DESCRIPTION
https://illuminate.atlassian.net/browse/PD-467