### PR TITLE
fix: remove mathjax font family override

### DIFF
--- a/src/components/components.css
+++ b/src/components/components.css
@@ -571,14 +571,6 @@ h1, h2, h3, h4, h5, h6 {
   width: auto;
 }
 
-.MJX-TEX * {
-  font-family: MJXZERO, MJXTEX, MJXTEX-S1, MJXTEX-S4, MJXTEX-A ! important;
-}
-
-mjx-math.MJX-TEX * {
-  font-family: MJXZERO, MJXTEX, MJXTEX-S1, MJXTEX-S4, MJXTEX-A ! important;
-}
-
 .TEX-S3 {
   font-family: MJXZERO, MJXTEX-S3 !important;
 }


### PR DESCRIPTION
Fixes https://illuminate.atlassian.net/browse/STU-765.

PRs where these lines were added: 
- https://github.com/pie-framework/pie-player-components/pull/73
- https://github.com/pie-framework/pie-player-components/pull/74

It seems overriding is not needed anymore - some items might have been fixed with: https://github.com/pie-framework/pie-lib/pull/424/files.