### PR TITLE
feat: integrate complex-rubric; deprecate rubric and multi-trait-rubric

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,7 +13,6 @@ import {
 import {
   ItemConfig,
   ItemSession,
-  PieContent,
   PieController,
   PieElement,
   PieModel,
@@ -28,11 +27,12 @@ import {
 export namespace Components {
   interface PieAuthor {
     /**
-    * Utility method to add a `@pie-element/multi-trait-rubric` section to an item config when creating an item should be used before setting the config. *
+    * Utility method to add a `@pie-element/multi-trait-rubric` section to an item config when creating an item should be used before setting the config.
+    * @deprecated this method was for temporary use, was removed in the latest major release *
     * @param config the item config to mutate
     * @param multiTraitRubricModel
     */
-    'addMultiTraitRubricToConfig': (config: ItemConfig, multiTraitRubricModel?: any) => Promise<PieContent>;
+    'addMultiTraitRubricToConfig': (config: ItemConfig, multiTraitRubricModel?: any) => Promise<ItemConfig>;
     /**
     * Adds a preview view which will render the content in another tab as it may appear to a student or instructor.
     */
@@ -43,11 +43,11 @@ export namespace Components {
     'addRubric': boolean;
     /**
     * Utility method to add a `@pie-element/rubric` section to an item config when creating an item should be used before setting the config.
-    * @deprecated this method is for temporary use, will be removed at next major release
+    * @deprecated this method was for temporary use, was removed in the latest major release
     * @param config the item config to mutate
     * @param rubricModel
     */
-    'addRubricToConfig': (config: ItemConfig, rubricModel?: any) => Promise<PieContent>;
+    'addRubricToConfig': (config: ItemConfig, rubricModel?: any) => Promise<ItemConfig>;
     /**
     * Provide this property override the default endpoints used by the player to retrieve JS bundles. Must be set before setting the config property. Most users will not need to use this property.
     */

--- a/src/demo/author-preview-add-rubric.html
+++ b/src/demo/author-preview-add-rubric.html
@@ -21,7 +21,8 @@
     elements: {
       'pie-multiple-choice': '@pie-element/multiple-choice@latest'
     },
-    models: [MC_model],
+    // TODO replace teacherInstructionsEnabled -> withRubric
+    models: [{ ...MC_model, teacherInstructionsEnabled: true }],
     markup: "<pie-multiple-choice id='1'></pie-multiple-choice>"
   };
 

--- a/src/demo/multi-item-rubric.html
+++ b/src/demo/multi-item-rubric.html
@@ -25,7 +25,8 @@
             "height": "200px",
             "showMathInput": false,
             "width": "500px",
-            "prompt": "<p>A bag contains 7 red cubes, 8 green cubes, 3 yellow cubes, 5 blue cubes, and 2 white cubes. All of the cubes are exactly the same size.</p>\r\n<p>A. Create a table that represents the contents of the bag and shows the probability of choosing each color when a cube is drawn from the bag without looking. Express the probabilities as fractions.</p>\r\n<p></p>"
+            "prompt": "<p>A bag contains 7 red cubes, 8 green cubes, 3 yellow cubes, 5 blue cubes, and 2 white cubes. All of the cubes are exactly the same size.</p>\r\n<p>A. Create a table that represents the contents of the bag and shows the probability of choosing each color when a cube is drawn from the bag without looking. Express the probabilities as fractions.</p>\r\n<p></p>",
+            teacherInstructionsEnabled: false
           },
           {
             "id": "4028e4a23e1a7e7c013e28b6d228132d",
@@ -33,7 +34,8 @@
             "height": "200px",
             "showMathInput": false,
             "width": "500px",
-            "prompt": "<p>B. Determine the probability of randomly drawing a green cube, returning it to the bag, and then randomly drawing a blue cube.</p>\r\n<ul>\r\n    <li>Explain how you can use your table to find the probability.</li>\r\n    <li>Write and solve an equation that represents the calculation of the probability.</li>\r\n</ul>\r\n<p></p>"
+            "prompt": "<p>B. Determine the probability of randomly drawing a green cube, returning it to the bag, and then randomly drawing a blue cube.</p>\r\n<ul>\r\n    <li>Explain how you can use your table to find the probability.</li>\r\n    <li>Write and solve an equation that represents the calculation of the probability.</li>\r\n</ul>\r\n<p></p>",
+            teacherInstructionsEnabled: true
           },
           {
             "width": "500px",
@@ -41,7 +43,8 @@
             "id": "4028e4a23e1a7e7c013e28bca5c91332",
             "element": "extended-text-entry",
             "height": "200px",
-            "showMathInput": false
+            "showMathInput": false,
+            teacherInstructionsEnabled: false
           },
           {
             "points": [
@@ -55,12 +58,32 @@
             "maxPoints": 4,
             "excludeZero": false,
             "element": "pie-rubric"
-          }
+          },
+          // {
+          //   "rubrics": {
+          //     "simpleRubric": {
+          //       "points": [
+          //         "<p>The response is completely incorrect, there is no response, or the response is off topic.</p>",
+          //         "<p>The response demonstrates minimal understanding. A level 1 response is characterized by:</p>\r\n<ul>\r\n    <li>A table in part A that exhibits up to 3 incorrect probabilities;</li>\r\n    <li>An explanation and an equation for part B that are incorrect, incomplete, or missing;</li>\r\n    <li>An explanation for part C that is incorrect, incomplete, or missing.</li>\r\n</ul>",
+          //         "<p>The response demonstrates a basic but incomplete understanding. A level 2 response is characterized by:</p>\r\n<ul>\r\n    <li>A table in part A that exhibits 1&#8211;2 incorrect probabilities;</li>\r\n    <li>An explanation for part B that is vague, incomplete, or missing;</li>\r\n    <li>An expression or equation for part B that is correctly derived from the table in part A but may be incorrectly solved;</li>\r\n    <li>An explanation for part C that is incomplete.</li>\r\n</ul>",
+          //         "<p>The response demonstrates a strong understanding, but the work contains minor errors. A level 3 response is characterized by:</p>\r\n<ul>\r\n    <li>A correctly drawn table in part A that may exhibit minor errors in labeling or organization;</li>\r\n    <li>An explanation for part B that contains minor flaws or is incomplete but correct;</li>\r\n    <li>An equation for part B that is solvable but may contain a minor flaw leading to an incorrect result;</li>\r\n    <li>An explanation in part C that indicates the event is more likely without replacement but may be incomplete or show inadequate supporting details OR leads to a well-supported conclusion that is consistent with calculation errors made in part B.</li>\r\n</ul>",
+          //         "<p>The response demonstrates a high level of understanding. A level 4 response is characterized by:</p>\r\n<ul>\r\n    <li>A correctly created and labeled table in part A, with probabilities expressed as fractions, similar to:</li>\r\n</ul>\r\n<p><img src=\"https://localhost:8443/ia/image/13d1a42cd5044dcab77b163343755157\" id=\"13d1a42cd5044dcab77b163343755157\" alt=\"image 13d1a42cd5044dcab77b163343755157\" /></p>\r\n<p>(Accept an unsimplified fraction (5/25) for the probability of Blue);</p>\r\n<ul>\r\n    <li>A correct explanation for part B indicating that the compound probability can be calculated as the product of the individual probabilities, similar to \"For the green cube you use the fraction 8/25 from the table, and for the blue cube you use the fraction 1/5 from the table. Then you multiply them together to get 8/125\";</li>\r\n    <li>A correct equation in part B, similar to 8/25&#160;&#215; 1/5 = <span class=\"variable\">p</span>, solved as 8/125;</li>\r\n    <li>A correct explanation with supporting work for part C indicating that the event is more likely when the green cube is not replaced. Justification should specify that without replacing the green cube the probability for the blue cube to be drawn second increases from 1/5 to 5/24; that the fraction 5/24 is greater than 1/5; and that there are fewer cubes in the box after the green cube is removed, so all cubes have a greater likelihood of being chosen on the second draw, or that the compound probability without replacing the green cube is 1/15, which is greater than 8/125. Accept correct models, such as tree diagrams or tables that clearly illustrate the increased likelihood and/or a clear comparison of equations and solutions representing the two events.</li>\r\n</ul>\r\n<p></p>"
+          //       ],
+          //       "maxPoints": 4,
+          //       "excludeZero": false
+          //     },
+          //     "multiTraitRubric": {}
+          //   },
+          //   "id": "p-4006dac7",
+          //   "element": "pp-pie-element-complex-rubric",
+          //   "type": "simpleRubric"
+          // }
         ],
         "markup": "<extended-text-entry id=\"4028e4a23e1a7e7c013e28b2be2d1326\"></extended-text-entry><extended-text-entry id=\"4028e4a23e1a7e7c013e28b6d228132d\"></extended-text-entry><extended-text-entry id=\"4028e4a23e1a7e7c013e28bca5c91332\"></extended-text-entry><pie-rubric id='rubric-4028e4a23e1a7e7c013e28b2be2d1325' />",
         "elements": {
           "pie-rubric": "@pie-element/rubric@latest",
-          "extended-text-entry": "@pie-element/extended-text-entry@latest"
+          "extended-text-entry": "@pie-element/extended-text-entry@latest",
+          // "pp-pie-element-complex-rubric": "@pie-element/complex-rubric@latest"
         }
       };
 

--- a/src/rubric-utils.ts
+++ b/src/rubric-utils.ts
@@ -34,6 +34,24 @@ export const addMarkupForPackage = (
 };
 
 /**
+ * Adds complex-rubric html to markup.
+ * @param content
+ */
+export const addComplexRubric = (content: PieContent): PieContent => {
+  return addMarkupForPackage(
+    cloneDeep(content),
+    "@pie-element/complex-rubric",
+    (id, tag, markup) => {
+      return `
+    ${markup}
+    <div style="width: 75%">
+      <${tag} id="${id}"></${tag}>
+    </div>
+    `;
+    }
+  );
+};
+/**
  * Adds rubric html to markup.
  * @param content
  */


### PR DESCRIPTION
BREAKING CHANGE: addRubric and addMultiTraitRubric methods can not be used anymore; rubric item type and multi-trait-rubric item type can not be used anymore. Instead, complex-rubric will be used, which contains both rubric and multi-trait-rubric.